### PR TITLE
Add environment variables. Allow trailing dot

### DIFF
--- a/flogging/__init__.py
+++ b/flogging/__init__.py
@@ -1,3 +1,1 @@
-from logging import getLogger
-
 from flogging.flogging import setup

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ from setuptools import find_packages, setup
 
 
 version = SourceFileLoader(
-    "flogging.version", str(Path(__file__).parent / "flogging" / "version.py"),
+    "flogging.version",
+    str(Path(__file__).parent / "flogging" / "version.py"),
 ).load_module()
 
 with open(Path(__file__).with_name("README.md"), encoding="utf-8") as f:


### PR DESCRIPTION
- Add environment variables to select `setup` parameters
- Allow to deactivate trailing dot errors (Some third party libs use trailing dots, so if we don't allow it `flogging` becomes useless in some cases)
- Removed `logging` imports in `__init__`