### PR TITLE
Single-call print with structured logging

### DIFF
--- a/flogging/flogging.py
+++ b/flogging/flogging.py
@@ -228,9 +228,7 @@ class StructuredHandler(logging.Handler):
             obj["context"] = self.local.context
         except AttributeError:
             pass
-        json.dump(obj, sys.stdout, sort_keys=True)
-        sys.stdout.write("\n")
-        sys.stdout.flush()
+        print(json.dumps(obj, sort_keys=True), file=sys.stdout, flush=True)
 
     def flush(self):
         """Write all pending text to stdout."""


### PR DESCRIPTION
Otherwise the logs can get mixed together in multiprocess programs